### PR TITLE
Expose number methods via PyNumberMethods.

### DIFF
--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -118,15 +118,6 @@ with the corresponding bitarray for each symbols."""
         _check_codedict(codedict)
         self._encode(codedict, iterable)
 
-    def __int__(self):
-        raise TypeError("int() argument cannot be a bitarray")
-
-    def __long__(self):
-        raise TypeError("long() argument cannot be a bitarray")
-
-    def __float__(self):
-        raise TypeError("float() argument cannot be a bitarray")
-
 
 def test(verbosity=1, repeat=1):
     """test(verbosity=1, repeat=1) -> TextTestResult

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -26,6 +26,7 @@ typedef char vec __attribute__((vector_size(16)));
 #define PyString_AsString  PyBytes_AsString
 #define PyString_ConcatAndDel  PyBytes_ConcatAndDel
 #define Py_TPFLAGS_HAVE_WEAKREFS  0
+#define Py_TPFLAGS_CHECKTYPES 0
 #endif
 
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION < 5
@@ -2111,51 +2112,39 @@ bitarray_cpinvert(bitarrayobject *self)
 /*
  * Generate function that performs bitwise operations.
  **/
-#define BITWISE_FUNC(OPNAME, OP, OPEQ)                                 \
-static int bitwise_ ## OPNAME (bitarrayobject *self, PyObject *arg)    \
-{                                                                      \
-    bitarrayobject *other;                                             \
-                                                                       \
-    if (!bitarray_Check(arg)) {                                        \
-        PyErr_SetString(PyExc_TypeError,                               \
-          "bitarray object expected for bitwise operation");           \
-        return -1;                                                     \
-    }                                                                  \
-                                                                       \
-    other = (bitarrayobject *) arg;                                    \
-                                                                       \
-    if (self->nbits != other->nbits) {                                 \
-        PyErr_SetString(PyExc_ValueError,                              \
-          "bitarrays of equal length expected for bitwise operation"); \
-        return -1;                                                     \
-    }                                                                  \
-                                                                       \
-    setunused(self);                                                   \
-    setunused(other);                                                  \
-                                                                       \
-    BITWISE_FUNC_INTERNAL(self, other, OP, OPEQ);                      \
-                                                                       \
-    return 0;                                                          \
+#define BITWISE_FUNC(OPNAME, OP, OPEQ)                                      \
+static int bitwise_ ## OPNAME (bitarrayobject *self, bitarrayobject *other) \
+{                                                                           \
+    if (self->nbits != other->nbits) {                                      \
+        PyErr_SetString(PyExc_ValueError,                                   \
+          "bitarrays of equal length expected for bitwise operation");      \
+        return -1;                                                          \
+    }                                                                       \
+    setunused(self);                                                        \
+    setunused(other);                                                       \
+    BITWISE_FUNC_INTERNAL(self, other, OP, OPEQ);                           \
+    return 0;                                                               \
 }
 
 BITWISE_FUNC(xor, ^, ^=)
 BITWISE_FUNC(and, &, &=)
 BITWISE_FUNC(or, |, |=)
 
-#define BITARRAY_FUNC(oper)  \
-static PyObject *                                                   \
-bitarray_ ## oper (bitarrayobject *self, PyObject *other)           \
-{                                                                   \
-    PyObject *res;                                                  \
-                                                                    \
-    res = bitarray_copy(self);                                      \
-                                                                    \
-    if (bitwise_ ## oper((bitarrayobject *) res, other) < 0) {      \
-        Py_DECREF(res);                                             \
-        return NULL;                                                \
-    }                                                               \
-                                                                    \
-    return res;                                                     \
+#define BITARRAY_FUNC(oper)                                                   \
+static PyObject *                                                             \
+bitarray_ ## oper (bitarrayobject *self, PyObject *other)                     \
+{                                                                             \
+    PyObject *res;                                                            \
+    if (!bitarray_Check(self) || !bitarray_Check(other)) {                    \
+        Py_INCREF(Py_NotImplemented);                                         \
+        return Py_NotImplemented;                                             \
+    }                                                                         \
+    res = bitarray_copy(self);                                                \
+    if (bitwise_ ## oper((bitarrayobject*)res, (bitarrayobject*)other) < 0) { \
+        Py_DECREF(res);                                                       \
+        return NULL;                                                          \
+    }                                                                         \
+    return res;                                                               \
 }
 
 BITARRAY_FUNC(and)
@@ -2163,20 +2152,127 @@ BITARRAY_FUNC(or)
 BITARRAY_FUNC(xor)
 
 
-#define BITARRAY_IFUNC(oper)  \
-static PyObject *                                            \
-bitarray_i ## oper (bitarrayobject *self, PyObject *other)   \
-{                                                            \
-    if (bitwise_ ## oper(self, other) < 0)                   \
-        return NULL;                                         \
-                                                             \
-    Py_INCREF(self);                                         \
-    return (PyObject *) self;                                \
+#define BITARRAY_IFUNC(oper)                                \
+static PyObject *                                           \
+bitarray_i ## oper (bitarrayobject *self, PyObject *other)  \
+{                                                           \
+    if (!bitarray_Check(other)) {                           \
+        Py_INCREF(Py_NotImplemented);                       \
+        return Py_NotImplemented;                           \
+    }                                                       \
+    if (bitwise_ ## oper(self, (bitarrayobject*)other) < 0) \
+        return NULL;                                        \
+    Py_INCREF(self);                                        \
+    return (PyObject *) self;                               \
 }
 
 BITARRAY_IFUNC(and)
 BITARRAY_IFUNC(or)
 BITARRAY_IFUNC(xor)
+
+static PyObject *
+bitarray_int(bitarrayobject *self)
+{
+    PyErr_SetString(PyExc_TypeError, "int() argument cannot be a bitarray");
+    return NULL;
+}
+
+#ifndef IS_PY3K
+static PyObject *
+bitarray_long(bitarrayobject *self)
+{
+    PyErr_SetString(PyExc_TypeError, "long() argument cannot be a bitarray");
+    return NULL;
+}
+#endif
+
+static PyObject *
+bitarray_float(bitarrayobject *self)
+{
+    PyErr_SetString(PyExc_TypeError, "float() argument cannot be a bitarray");
+    return NULL;
+}
+
+#ifdef IS_PY3K
+static PyNumberMethods bitarray_as_number = {
+    0,                            /* nb_add */
+    0,                            /* nb_subtract */
+    0,                            /* nb_multiply */
+    0,                            /* nb_remainder */
+    0,                            /* nb_divmod */
+    0,                            /* nb_power */
+    0,                            /* nb_negative */
+    0,                            /* nb_positive */
+    0,                            /* nb_absolute */
+    0,                            /* nb_bool */
+    (unaryfunc)bitarray_cpinvert, /* nb_invert */
+    0,                            /* nb_lshift */
+    0,                            /* nb_rshift */
+    (binaryfunc)bitarray_and,     /* nb_and */
+    (binaryfunc)bitarray_xor,     /* nb_xor */
+    (binaryfunc)bitarray_or,      /* nb_or */
+    (unaryfunc)bitarray_int,      /* nb_int */
+    0,                            /* nb_reserved */
+    (unaryfunc)bitarray_float,    /* nb_float */
+    0,                            /* nb_inplace_add */
+    0,                            /* nb_inplace_subtract */
+    0,                            /* nb_inplace_multiply */
+    0,                            /* nb_inplace_remainder */
+    0,                            /* nb_inplace_power */
+    0,                            /* nb_inplace_lshift */
+    0,                            /* nb_inplace_rshift */
+    (binaryfunc)bitarray_iand,    /* nb_inplace_and */
+    (binaryfunc)bitarray_ixor,    /* nb_inplace_xor */
+    (binaryfunc)bitarray_ior,     /* nb_inplace_or */
+    0,                            /* nb_floor_divide */
+    0,                            /* nb_true_divide */
+    0,                            /* nb_inplace_floor_divide */
+    0,                            /* nb_inplace_true_divide */
+    0,                            /* nb_index */
+};
+#else
+static PyNumberMethods bitarray_as_number = {
+    0,                            /* nb_add */
+    0,                            /* nb_subtract */
+    0,                            /* nb_multiply */
+    0,                            /* nb_divide */
+    0,                            /* nb_remainder */
+    0,                            /* nb_divmod */
+    0,                            /* nb_power */
+    0,                            /* nb_negative */
+    0,                            /* nb_positive */
+    0,                            /* nb_absolute */
+    0,                            /* nb_nonzero */
+    (unaryfunc)bitarray_cpinvert, /* nb_invert */
+    0,                            /* nb_lshift */
+    0,                            /* nb_rshift */
+    (binaryfunc)bitarray_and,     /* nb_and */
+    (binaryfunc)bitarray_xor,     /* nb_xor */
+    (binaryfunc)bitarray_or,      /* nb_or */
+    0,                            /* nb_coerce */
+    (unaryfunc)bitarray_int,      /* nb_int */
+    (unaryfunc)bitarray_long,     /* nb_long */
+    (unaryfunc)bitarray_float,    /* nb_float */
+    0,                            /* nb_oct */
+    0,                            /* nb_hex */
+    0,                            /* nb_inplace_add */
+    0,                            /* nb_inplace_subtract */
+    0,                            /* nb_inplace_multiply */
+    0,                            /* nb_inplace_divide */
+    0,                            /* nb_inplace_remainder */
+    0,                            /* nb_inplace_power */
+    0,                            /* nb_inplace_lshift */
+    0,                            /* nb_inplace_rshift */
+    (binaryfunc)bitarray_iand,    /* nb_inplace_and */
+    (binaryfunc)bitarray_ixor,    /* nb_inplace_xor */
+    (binaryfunc)bitarray_ior,     /* nb_inplace_or */
+    0,                            /* nb_floor_divide */
+    0,                            /* nb_true_divide */
+    0,                            /* nb_inplace_floor_divide */
+    0,                            /* nb_inplace_true_divide */
+    0,                            /* nb_index */
+};
+#endif
 
 /******************* variable length encoding and decoding ***************/
 
@@ -2579,15 +2675,6 @@ bitarray_methods[] = {
     {"__reduce__",   (PyCFunction) bitarray_reduce,      METH_NOARGS,
      reduce_doc},
 
-    /* number methods */
-    {"__and__",      (PyCFunction) bitarray_and,         METH_O,       0},
-    {"__or__",       (PyCFunction) bitarray_or,          METH_O,       0},
-    {"__xor__",      (PyCFunction) bitarray_xor,         METH_O,       0},
-    {"__iand__",     (PyCFunction) bitarray_iand,        METH_O,       0},
-    {"__ior__",      (PyCFunction) bitarray_ior,         METH_O,       0},
-    {"__ixor__",     (PyCFunction) bitarray_ixor,        METH_O,       0},
-    {"__invert__",   (PyCFunction) bitarray_cpinvert,    METH_NOARGS,  0},
-
     {NULL,           NULL}  /* sentinel */
 };
 
@@ -2949,7 +3036,7 @@ static PyTypeObject Bitarraytype = {
     0,                                        /* tp_setattr */
     0,                                        /* tp_compare */
     (reprfunc) bitarray_repr,                 /* tp_repr */
-    0,                                        /* tp_as_number*/
+    &bitarray_as_number,                      /* tp_as_number*/
     &bitarray_as_sequence,                    /* tp_as_sequence */
     &bitarray_as_mapping,                     /* tp_as_mapping */
     0,                                        /* tp_hash */
@@ -2963,6 +3050,7 @@ static PyTypeObject Bitarraytype = {
     0,                                        /* tp_as_buffer */
 #endif
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_WEAKREFS
+    | Py_TPFLAGS_CHECKTYPES
 #ifdef WITH_BUFFER
     | Py_TPFLAGS_HAVE_NEWBUFFER
 #endif

--- a/test/bench_bitarray.py
+++ b/test/bench_bitarray.py
@@ -24,8 +24,28 @@ def bench_sequence():
             print('%-24s %.8f\t%s' % (op + ' took:', t, b))
         print('')
 
+def bench_number():
+    print('Benchmarking number methods')
+    baseline = []
+    for name, setup in [('int', 'n = 0x12341234'),
+                        ('bitarray', 'from bitarray import bitarray;' +
+                                     'n = bitarray([0, 1])')]:
+        print('=== Testing ' + name)
+        for i, op in enumerate(['~n', 'not n',
+                                'n & n', 'n | n', 'n ^ n',
+                                'n &= n', 'n |= n', 'n ^= n']):
+            t = min(timeit.repeat(op, setup))
+            if i < len(baseline):
+                b = t / baseline[i]
+            else:
+                b = ''
+                baseline.append(t)
+            print('%-24s %.8f\t%s' % (op + ' took:', t, b))
+        print('')
+
 def run():
     bench_sequence()
+    bench_number()
 
 if __name__ == '__main__':
     run()

--- a/test/test_bitarray.py
+++ b/test/test_bitarray.py
@@ -964,7 +964,7 @@ class BitwiseTests(unittest.TestCase, Util):
         b = bitarray('1001')
         self.assertRaises(ValueError, a.__and__, b) # not same length
 
-        self.assertRaises(TypeError, a.__and__, 42)
+        self.assertRaises(TypeError, lambda: a & 42)
 
     def test_iand(self):
         a =  bitarray('110010110')


### PR DESCRIPTION
Same as with the sequence methods, this is more efficient:
#### Without my changes

| Method | Time | Time / Int Time |
| --- | --: | --: |
| ~n | 0.15731502 | 6.60738819571 |
| not n | 0.09582591 | 4.24574024191 |
| n & n | 0.25910902 | 8.98530809997 |
| n | n | 0.24405813 | 8.56255959849 |
| n ^ n | 0.26799893 | 10.3437807695 |
| n &= n | 0.15009093 | 4.7497132941 |
| n |= n | 0.15412307 | 5.11443490644 |
| n ^= n | 0.15293598 | 5.40846352959 |
#### With my changes

| Method | Time | Time / Int Time |
| --- | --: | --: |
| ~n | 0.09859705 | 4.17870964482 |
| not n | 0.02347922 | 1.06352257633 |
| n & n | 0.15802598 | 5.56467970783 |
| n | n | 0.15931797 | 5.64720398212 |
| n ^ n | 0.17296290 | 6.74212135575 |
| n &= n | 0.06629801 | 2.15462695356 |
| n |= n | 0.06553197 | 2.21512040231 |
| n ^= n | 0.06492305 | 2.32224970152 |

The last column is time relative to int.

This gives an average speed up of 2x on this benchmark. Of course,
longer arrays will see smaller improvements.
