### PR TITLE
Add MANIFEST.in so README.rst is included in the package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst


### PR DESCRIPTION
When building a package to upload to a local pypi, the package is
broken because the README.rst is not included in the package. Adding
a MANIFEST.in including the README.rst will fix this problem.
